### PR TITLE
Decrease appcompat version to 1.0.2

### DIFF
--- a/rxsmartlock/build.gradle
+++ b/rxsmartlock/build.gradle
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.media:media:1.1.0'
 
     implementation 'javax.inject:javax.inject:1'


### PR DESCRIPTION
androidx.appcompat itself depends on androidx.fragment 1.1.0. This version of androidx.fragment can lead to the crash whenever the user navigates back: issuetracker.google.com/issues/142268508

Decreasing to appcompat version 1.0.2 should solve the issue.