### PR TITLE
Remove supportRtl definition from manifest

### DIFF
--- a/rxsmartlock/src/main/AndroidManifest.xml
+++ b/rxsmartlock/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.freeletics.rxsmartlock">
 
-    <application android:supportsRtl="true">
+    <application>
 
         <activity
             android:name="HiddenSmartLockActivity"


### PR DESCRIPTION
It's not needed here. The library does not show any UI on it's own.