### PR TITLE
Fix RxGoogleSmartLock does not handle properly shared google api client

### DIFF
--- a/rxsmartlock/src/main/java/com/freeletics/rxsmartlock/HiddenSmartLockActivity.kt
+++ b/rxsmartlock/src/main/java/com/freeletics/rxsmartlock/HiddenSmartLockActivity.kt
@@ -14,9 +14,7 @@ class HiddenSmartLockActivity : FragmentActivity() {
             "SmartLock: HiddenSmartLockActivity::onCreate fresh=%b",
             savedInstanceState == null
         )
-        if (savedInstanceState == null) {
-            handleIntent()
-        }
+        handleIntent()
     }
 
     override fun onNewIntent(intent: Intent) {


### PR DESCRIPTION
Missed in my previous PR #59 that `.publish()` actually does not prevent upstream to be called once and that may cause check to be triggered here: https://github.com/freeletics/RxSmartLock/blob/0e6becb6648884193008fa6e24e2c9f1e8fb1b77/rxsmartlock/src/main/java/com/freeletics/rxsmartlock/RxGoogleSmartLockManager.kt#L128

Updated the code to count connected streams and only dispose `googleApiClient` in case when it is last connected stream. When new steam asks for a `googleApiClient`, `RxGoogleSmartLock` will reuse already connected `googleApiClient`.

To test this change with our main app you could add following in `settings.gradle`:
```gradle
includeBuild("../RxSmartLock") {
    dependencySubstitution {
        substitute module("com.freeletics.rxsmartlock:rxsmartlock") with project(":rxsmartlock")
    }
}
```