### PR TITLE
Check for hint intent to be present in HiddenSmartLockActivity

### DIFF
--- a/rxsmartlock/src/main/java/com/freeletics/rxsmartlock/HiddenSmartLockActivity.kt
+++ b/rxsmartlock/src/main/java/com/freeletics/rxsmartlock/HiddenSmartLockActivity.kt
@@ -24,11 +24,17 @@ class HiddenSmartLockActivity : FragmentActivity() {
     }
 
     private fun handleIntent(intent: Intent) {
-        val hintIntent: PendingIntent = intent.getParcelableExtra(EXTRA_HINT_INTENT)!!
-        startIntentSenderForResult(
-            hintIntent.intentSender,
-            REQUEST_CODE_RESOLVE_HINTS, null, 0, 0, 0
-        )
+        val hintIntent: PendingIntent? = intent.getParcelableExtra(EXTRA_HINT_INTENT)
+        if (hintIntent != null) {
+            startIntentSenderForResult(
+                    hintIntent.intentSender,
+                    REQUEST_CODE_RESOLVE_HINTS, null, 0, 0, 0
+            )
+        } else {
+            // finish with error
+            RxGoogleSmartLockManager.handleActivityResult(RESULT_CANCELED, null)
+            finish()
+        }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {


### PR DESCRIPTION
Finish with error in case intent is missing. This fixes weird crashes where Activity was opened without hint intent.